### PR TITLE
Avoid loading a new Datafile on every request

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,8 +59,12 @@ function initialize(options) {
   }
 
   const manager = optimizelyClient.projectConfigManager.datafileManager;
-  manager.on('update', updateDatafile);
-  manager.onReady().then(updateDatafile);
+  if (manager) {
+    manager.on('update', updateDatafile);
+    manager.onReady().then(updateDatafile);
+  } else {
+    optimizelyClient.logger.warn('Failed to initialize a DatafileManager')
+  }
 
   return {
     /**

--- a/index.js
+++ b/index.js
@@ -61,7 +61,6 @@ function initialize(options) {
   const manager = optimizelyClient.projectConfigManager.datafileManager;
   manager.on('update', updateDatafile);
   manager.onReady().then(updateDatafile);
-  manager.start();
 
   return {
     /**

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function initialize(options) {
     console.log('[OPTIMIZELY] Datafile Updated!');
   }
 
-  const manager = optimizelyClient.projectConfigManager.datafileManager
+  const manager = optimizelyClient.projectConfigManager.datafileManager;
   manager.on('update', updateDatafile);
   manager.onReady().then(updateDatafile);
   manager.start();


### PR DESCRIPTION
Closes #4.

This makes it so that the SDK is only loaded once per process (when the server is initialized). Instead of having two separate DatafileManagers (one that pulls the datafile on every request, and one that pulls the datafile periodically), the middleware will now hook into the Optimizely client itself and use the client's DatafileManager to update its own copy of the datafile.

By only initializing the SDK once, we avoid fetching a new copy of the datafile on every request and instead honor the settings the user set up when instantiating the Express middleware.