### PR TITLE
fix (datafile-fetch): Prevent SDK from fetching datafile first time

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ function initialize(options) {
           logLevel: logLevel
         }),
         ...options,
+        sdkKey: undefined, // Ensure the SDK doesn't try to fetch the datafile on its own
         datafileOptions: {
           autoUpdate: false, // Ensure the SDK doesn't also try to auto-update on its own
         },


### PR DESCRIPTION
This is an alternative fix for issue: https://github.com/optimizely/express-middleware/issues/4

The mistake was assuming that passing a datafile into `createInstance` would prevent the SDK from trying to fetch a datafile from the CDN. But `createInstance` will always fetch the datafile upon initialization if it has an SDK key, so the logic behind this fix is to ensure that no SDK key is passed to `createInstance`